### PR TITLE
Fix file flush issue for visualization.sam

### DIFF
--- a/src/CRISPRlungo_visualization.py
+++ b/src/CRISPRlungo_visualization.py
@@ -2021,7 +2021,7 @@ def make_visualization_sam(dict_of_reads, out_dir):
 				line += f'\t{sa_tags[idx]}'
 			fw.write(line + '\n')
 
-
+	fw.close()
 	subprocess.run(f"samtools sort {out_dir}/visualization.sam -o {out_dir}/visualization.sorted.bam", shell=True, check=True)
 	subprocess.run(f"samtools index {out_dir}/visualization.sorted.bam", shell=True, check=True) 
 	subprocess.run(f"samtools faidx {ref_dir}/ref_wo_umi.fasta", shell=True, check=True) 
@@ -2079,7 +2079,7 @@ def make_visualization_sam(dict_of_reads, out_dir):
 	print(f"       (User can open this single file to load everything)")
 
 
-	fw.close()
+
 			
 
 


### PR DESCRIPTION
The `make_visualization_sam` function writes SAM data to `visualization.sam` using a file handle `fw`. After writing all records, the script immediately invokes `samtools sort` on this file before calling `fw.close()`. Because Python buffers file writes, the SAM data may not be fully flushed to disk when sorting, leading to missing data in the resulting BAM file.

This PR moves `fw.close()` to execute immediately after all SAM records are written and before `samtools sort`.